### PR TITLE
Return `BatchedFn` instance from `batched_fn!` macro instead of closure to avoid requiring static parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- ⚠️ Breaking change ⚠️
+
+  The `batched_fn!` macro now returns a `BatchedFn` instance instead of a closure, which allows
+  us to avoid requiring static parameters to the macro.
+  It's a simple change to upgrade your codebase. If your code looked like this before:
+
+  ```rust
+  let batch_predictor = batched_fn! { ... };
+  return batch_predictor(input);
+  ```
+
+  You just need to change the last line to:
+
+  ```rust
+  return batch_predictor.evaluate_in_batch(input);
+  ```
+
 ## [v0.2.4](https://github.com/epwalsh/batched-fn/releases/tag/v0.2.4) - 2022-03-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ```rust
   let batch_predictor = batched_fn! { ... };
-  return batch_predictor(input);
+  return batch_predictor(input).await;
   ```
 
   You just need to change the last line to:
 
   ```rust
-  return batch_predictor.evaluate_in_batch(input);
+  return batch_predictor.evaluate_in_batch(input).await;
   ```
 
 ## [v0.2.4](https://github.com/epwalsh/batched-fn/releases/tag/v0.2.4) - 2022-03-14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["time", "rt", "rt-multi-thread", "macros"] }
+once_cell = "1.3.1"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -31,21 +31,22 @@ impl Model {
 }
 
 async fn predict_for_single_input(input: Input) -> Output {
-    let batch_predict = batched_fn! {
+    let max_batch_size = if true { 4 } else { 8 };
+    let batched_predictor = batched_fn! {
         handler = |batch: Batch<Input>, model: &Model| -> Batch<Output> {
             let output = model.predict(batch.clone());
             println!("Processed batch {:?} -> {:?}", batch, output);
             output
         };
         config = {
-            max_batch_size: 4,
+            max_batch_size: max_batch_size,
             max_delay: 50,
         };
         context = {
             model: Model::load(),
         };
     };
-    batch_predict(input).await.unwrap()
+    batched_predictor.evaluate_in_batch(input).await.unwrap()
 }
 
 #[tokio::main]

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -31,7 +31,6 @@ impl Model {
 }
 
 async fn predict_for_single_input(input: Input) -> Output {
-    let max_batch_size = if true { 4 } else { 8 };
     let batched_predictor = batched_fn! {
         handler = |batch: Batch<Input>, model: &Model| -> Batch<Output> {
             let output = model.predict(batch.clone());
@@ -39,7 +38,7 @@ async fn predict_for_single_input(input: Input) -> Output {
             output
         };
         config = {
-            max_batch_size: max_batch_size,
+            max_batch_size: 4,
             max_delay: 50,
         };
         context = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Features
 //!
-//! - 🚀 Easy to use: drop the `batched_fn!` macro into existing code.
+//! - 🚀 Easy to use: drop the [`batched_fn!`](crate::batched_fn) macro into existing code.
 //! - 🔥 Lightweight and fast: queue system implemented on top of the blazingly fast [flume crate](https://github.com/zesterer/flume).
 //! - 🙌 Easy to tune: simply adjust [`max_delay`](crate::batched_fn#config) and [`max_batch_size`](crate::batched_fn#config).
 //! - 🛑 [Back pressure](https://medium.com/@jayphelps/backpressure-explained-the-flow-of-data-through-software-2350b3e77ce7) mechanism included:
@@ -78,7 +78,7 @@
 //! }
 //! ```
 //!
-//! But by dropping the [`batched_fn`](crate::batched_fn) macro into your code you automatically get batched
+//! But by dropping the [`batched_fn!`](crate::batched_fn) macro into your code you automatically get batched
 //! inference behind the scenes without changing the one-to-one relationship between inputs and
 //! outputs:
 //!
@@ -130,15 +130,16 @@
 //!
 //! ## Implementation details
 //!
-//! When the `batched_fn` macro is invoked it spawns a new thread where the
+//! When the [`batched_fn!`](crate::batched_fn) macro is invoked it spawns a new thread where the
 //! [`handler`](crate::batched_fn#handler) will
 //! be ran. Within that thread, every object specified in the [`context`](crate::batched_fn#context)
 //! is initialized and then passed by reference to the handler each time it is run.
 //!
-//! The object returned by the macro is just a closure that sends a single input and a callback
-//! through an asyncronous channel to the handler thread. When the handler finishes
-//! running a batch it invokes the callback corresponding to each input with the corresponding output,
-//! which triggers the closure to wake up and return the output.
+//! The object returned by the macro is just an instance of the [`BatchedFn`](crate::BatchedFn)
+//! struct. When you call [`.evaluate_in_batch()`](crate::BatchedFn#method.evaluate_in_batch) on this instance,
+//! it sends a single input and a callback through an asyncronous channel to the handler thread.
+//! When the handler finishes running a batch it invokes the callback corresponding to each input with the corresponding output,
+//! which triggers the calling thread to wake up and return the output.
 
 extern crate flume;
 extern crate once_cell;
@@ -358,8 +359,7 @@ macro_rules! __batched_fn_internal {
 /// Macro for creating a batched function.
 ///
 /// This macro has 3 parameters: [`handler`](#handler), [`config`](#config), and
-/// [`context`](#context). It returns an async function that wraps
-/// [`BatchedFn::evaluate_in_batch`](struct.BatchedFn.html#method.evaluate_in_batch).
+/// [`context`](#context). It returns an instance of async function [`BatchedFn`](crate::BatchedFn).
 ///
 /// # Parameters
 ///
@@ -408,7 +408,7 @@ macro_rules! __batched_fn_internal {
 ///         context = {};
 ///     };
 ///
-///     batched_double(x).await
+///     batched_double.evaluate_in_batch(x).await
 /// }
 /// ```
 ///
@@ -432,7 +432,7 @@ macro_rules! __batched_fn_internal {
 ///         };
 ///     };
 ///
-///     batched_multiply(x).await
+///     batched_multiply.evaluate_in_batch(x).await
 /// }
 /// ```
 #[macro_export]

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -7,7 +7,7 @@ type TestResult = (Vec<i32>, Vec<i32>);
 static TEST_RESULTS: Lazy<Mutex<Vec<TestResult>>> = Lazy::new(|| Mutex::new(vec![]));
 
 async fn double(x: i32) -> i32 {
-    let batched = batched_fn! {
+    let batch_handler = batched_fn! {
         handler = |batch: Vec<i32>| -> Vec<i32> {
             let mut out = Vec::with_capacity(batch.len());
             for x in &batch {
@@ -23,7 +23,7 @@ async fn double(x: i32) -> i32 {
         context = {};
     };
 
-    batched(x).await.unwrap()
+    batch_handler.evaluate_in_batch(x).await.unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #20 